### PR TITLE
Fix rdf about

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ Change Log
 * Added search field to Terms Admin.
 * Fixed vocabulary links in admin interface.
 * Removed Definition option in PROPERTY_NAME_CHOICES.
-* Bump lxml version.
-* Fix admin links in models.
-
+* Bumped lxml version.
+* Fixed admin links in models.
+* Fixed [issue #35](https://github.com/unt-libraries/django-controlled-vocabularies/issues/35) to correct XML format rdf:about value.
 
 3.0.0
 -----

--- a/controlled_vocabularies/vocabulary_handler.py
+++ b/controlled_vocabularies/vocabulary_handler.py
@@ -1,7 +1,8 @@
-from lxml.etree import Element, SubElement, tostring, register_namespace
 import json
+
 from controlled_vocabularies.models import Term, Property
 from django.conf import settings
+from lxml.etree import Element, SubElement, tostring, register_namespace
 
 
 class VocabularyHandler:
@@ -25,7 +26,7 @@ class VocabularyHandler:
         rdf_namespace = "{%s}" % (rdf_url)
         dc_namespace = "{%s}" % (dc_url)
         rdfs_namespace = "{%s}" % (rdfs_url)
-        purl_namespace = 'http://purl.org/NET/UNTL/vocabularies/formats/'
+        purl_namespace = 'http://purl.org/NET/UNTL/vocabularies/' + c.vocab.name
         # Define Static Attributes
         isDefinedBy_attribs = {'{%s}resource' % rdf_url: purl_namespace}
         # Root

--- a/tests/test_vocabulary_handler.py
+++ b/tests/test_vocabulary_handler.py
@@ -17,7 +17,7 @@ NS = {
     'rdfs': RDFS
 }
 
-PURL = 'http://purl.org/NET/UNTL/vocabularies/formats/'
+PURL = 'http://purl.org/NET/UNTL/vocabularies/'
 
 
 def test_xml_response():
@@ -42,11 +42,11 @@ def test_create_xml_RDF_element(vocab_file_xml):
 
 
 def test_create_xml_Description_element(vocab_file_xml):
-    _, root = vocab_file_xml
+    prop, root = vocab_file_xml
 
     element = root.xpath('rdf:Description', namespaces=NS)[0]
     attrib = element.get('{{{}}}about'.format(RDF))
-    assert attrib == PURL
+    assert attrib == PURL + prop.term_key.vocab_list.name
 
 
 def test_create_xml_title_element(vocab_file_xml):
@@ -89,7 +89,7 @@ def test_create_xml_Property_element(vocab_file_xml):
 
     element = root.xpath('rdf:Property', namespaces=NS)[0]
     attrib = element.get('{{{}}}about'.format(RDF))
-    assert attrib == '{}#{}'.format(PURL, prop.term_key.name)
+    assert attrib == '{}#{}'.format(PURL + prop.term_key.vocab_list.name, prop.term_key.name)
 
 
 def test_create_xml_label_element(vocab_file_xml):
@@ -107,11 +107,11 @@ def test_create_xml_Property_subelement_description(vocab_file_xml):
 
 
 def test_create_xml_isDefinedBy_element(vocab_file_xml):
-    _, root = vocab_file_xml
+    prop, root = vocab_file_xml
 
     element = root.xpath('rdf:Property/rdfs:isDefinedBy', namespaces=NS)[0]
     attrib = element.get('{{{}}}resource'.format(RDF))
-    assert attrib == PURL
+    assert attrib == PURL + prop.term_key.vocab_list.name
 
 
 def test_py_response():


### PR DESCRIPTION
This updates the vocabularies' XML format rdf:about value to use the correct vocabulary name, instead of hard coding "formats" to fix #35.