### PR TITLE
remove vocabularies/ where we have the domain listed

### DIFF
--- a/controlled_vocabularies/templates/vocabularies/term_list.html
+++ b/controlled_vocabularies/templates/vocabularies/term_list.html
@@ -17,8 +17,8 @@ json</a>
     </tr>
     <tr>
         <td>URI:&nbsp;</td>
-        <td><a href='{{ domain }}vocabularies/{{ vocabulary.name }}/#{{term.term_item.name}}'>
-        {{ domain }}vocabularies/{{ vocabulary.name }}/#{{term.term_item.name}}</a>
+        <td><a href='{{ domain }}{{ vocabulary.name }}/#{{term.term_item.name}}'>
+        {{ domain }}{{ vocabulary.name }}/#{{term.term_item.name}}</a>
         </td></tr>
     <tr>
         <td>Label:&nbsp;</td>

--- a/controlled_vocabularies/views.py
+++ b/controlled_vocabularies/views.py
@@ -81,7 +81,7 @@ def verbose_vocabularies(request, file_format='py'):
         # Loop through the terms
         for term in ordered_term_objects:
             # Create the url for the term
-            term_url = "%svocabularies/%s/#%s" % \
+            term_url = "%s%s/#%s" % \
                 (settings.VOCAB_DOMAIN, vocab.name, term.name)
             # Create the term data dictionary
             term_dict = {


### PR DESCRIPTION
To fix some urls that would end up with 'https://digital2.library.unt.edu/vocabularies/vocabularies' instead of 'https://digital2.library.unt.edu/vocabularies/'.